### PR TITLE
feature: optionally decode object value null as nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ If disabled, JSON null values will be decoded as cjson.null.
 The `enabled` argument is a boolean.
 
 
-Exaample:
+Example:
 
 ```lua
 local cjson = require "cjson"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Table of Contents
     * [encode_number_precision](#encode_number_precision)
     * [encode_escape_forward_slash](#encode_escape_forward_slash)
     * [decode_array_with_array_mt](#decode_array_with_array_mt)
+    * [decode_null_object_value_as_nil](#decode_null_object_value_as_nil)
 
 Description
 ===========
@@ -206,3 +207,31 @@ cjson.encode(t) -- {"my_array":[]} properly re-encoded as an array
 ```
 
 [Back to TOC](#table-of-contents)
+
+
+decode_null_object_value_as_nil
+------------------------------
+**syntax:** `cjson.decode_null_object_value_as_nil(enabled)`
+
+**default:** false
+
+If enabled, JSON null values that are values of object keys will be decoded as Lua nil.
+If disabled, JSON null values will be decoded as cjson.null.
+
+`null` in array are always decoded as cjson.null.
+
+The `enabled` argument is a boolean.
+
+
+Exaample:
+
+```lua
+local cjson = require "cjson"
+local json = [[{"key1":null,"key2":"value2"}]]
+local t = cjson.decode(json)
+print(t.key1 == cjson.null) -- true
+
+cjson.decode_null_object_value_as_nil(true)
+local t2 = cjson.decode(json)
+print(t2.key1 == nil) -- true
+```

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -84,7 +84,7 @@
 #define DEFAULT_DECODE_ARRAY_WITH_ARRAY_MT 0
 #define DEFAULT_ENCODE_ESCAPE_FORWARD_SLASH 1
 #define DEFAULT_ENCODE_SKIP_UNSUPPORTED_VALUE_TYPES 0
-#define DEFAULT_DECODE_NULL_AS_NIL 0
+#define DEFAULT_decode_null_object_value_as_nil 0
 
 #ifdef DISABLE_INVALID_NUMBERS
 #undef DEFAULT_DECODE_INVALID_NUMBERS
@@ -169,7 +169,7 @@ typedef struct {
     int decode_max_depth;
     int decode_array_with_array_mt;
     int encode_skip_unsupported_value_types;
-    int decode_null_as_nil;
+    int decode_null_object_value_as_nil;
 } json_config_t;
 
 typedef struct {
@@ -393,11 +393,11 @@ static int json_cfg_encode_keep_buffer(lua_State *l)
 }
 
 /* Configures how to treat null when decoding */
-static int json_cfg_decode_null_as_nil(lua_State *l)
+static int json_cfg_decode_null_object_value_as_nil(lua_State *l)
 {
     json_config_t *cfg = json_arg_init(l, 1);
 
-    json_enum_option(l, 1, &cfg->decode_null_as_nil, NULL, 1);
+    json_enum_option(l, 1, &cfg->decode_null_object_value_as_nil, NULL, 1);
 
     return 1;
 }
@@ -493,7 +493,7 @@ static void json_create_config(lua_State *l)
     cfg->decode_array_with_array_mt = DEFAULT_DECODE_ARRAY_WITH_ARRAY_MT;
     cfg->encode_escape_forward_slash = DEFAULT_ENCODE_ESCAPE_FORWARD_SLASH;
     cfg->encode_skip_unsupported_value_types = DEFAULT_ENCODE_SKIP_UNSUPPORTED_VALUE_TYPES;
-    cfg->decode_null_as_nil = DEFAULT_DECODE_NULL_AS_NIL;
+    cfg->decode_null_object_value_as_nil = DEFAULT_decode_null_object_value_as_nil;
 
 #if DEFAULT_ENCODE_KEEP_BUFFER > 0
     strbuf_init(&cfg->encode_buf, 0);
@@ -896,7 +896,7 @@ static int json_encode(lua_State *l)
 /* ===== DECODING ===== */
 
 static void json_process_value(lua_State *l, json_parse_t *json,
-                               json_token_t *token);
+                               json_token_t *token, int decode_null_object_value_as_nil);
 
 static int hexdigit2int(char hex)
 {
@@ -1325,7 +1325,8 @@ static void json_parse_object_context(lua_State *l, json_parse_t *json)
 
         /* Fetch value */
         json_next_token(json, &token);
-        json_process_value(l, json, &token);
+        json_process_value(l, json, &token,
+                           json->cfg && json->cfg->decode_null_object_value_as_nil);
 
         /* Set key = value */
         lua_rawset(l, -3);
@@ -1372,7 +1373,7 @@ static void json_parse_array_context(lua_State *l, json_parse_t *json)
     }
 
     for (i = 1; ; i++) {
-        json_process_value(l, json, &token);
+        json_process_value(l, json, &token, 0);
         lua_rawseti(l, -2, i);            /* arr[i] = value */
 
         json_next_token(json, &token);
@@ -1391,7 +1392,7 @@ static void json_parse_array_context(lua_State *l, json_parse_t *json)
 
 /* Handle the "value" context */
 static void json_process_value(lua_State *l, json_parse_t *json,
-                               json_token_t *token)
+                               json_token_t *token, int decode_null_object_value_as_nil)
 {
     switch (token->type) {
     case T_STRING:
@@ -1412,7 +1413,7 @@ static void json_process_value(lua_State *l, json_parse_t *json,
     case T_NULL:
         /* In Lua, setting "t[k] = nil" will delete k from the table.
          * Hence a NULL pointer lightuserdata object is used instead */
-        if (json->cfg && json->cfg->decode_null_as_nil)
+        if (decode_null_object_value_as_nil)
             lua_pushnil(l);
         else
             lua_pushlightuserdata(l, NULL);
@@ -1449,7 +1450,7 @@ static int json_decode(lua_State *l)
     json.tmp = strbuf_new(json_len);
 
     json_next_token(&json, &token);
-    json_process_value(l, &json, &token);
+    json_process_value(l, &json, &token, 0);
 
     /* Ensure there is no more input left */
     json_next_token(&json, &token);
@@ -1537,7 +1538,7 @@ static int lua_cjson_new(lua_State *l)
         { "decode_invalid_numbers", json_cfg_decode_invalid_numbers },
         { "encode_escape_forward_slash", json_cfg_encode_escape_forward_slash },
         { "encode_skip_unsupported_value_types", json_cfg_encode_skip_unsupported_value_types },
-        { "decode_null_as_nil", json_cfg_decode_null_as_nil },
+        { "decode_null_object_value_as_nil", json_cfg_decode_null_object_value_as_nil },
         { "new", lua_cjson_new },
         { NULL, NULL }
     };

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -1537,7 +1537,7 @@ static int lua_cjson_new(lua_State *l)
         { "decode_invalid_numbers", json_cfg_decode_invalid_numbers },
         { "encode_escape_forward_slash", json_cfg_encode_escape_forward_slash },
         { "encode_skip_unsupported_value_types", json_cfg_encode_skip_unsupported_value_types },
-        { "decode_null_as_nil" , json_cfg_decode_null_as_nil },
+        { "decode_null_as_nil", json_cfg_decode_null_as_nil },
         { "new", lua_cjson_new },
         { NULL, NULL }
     };

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -84,7 +84,7 @@
 #define DEFAULT_DECODE_ARRAY_WITH_ARRAY_MT 0
 #define DEFAULT_ENCODE_ESCAPE_FORWARD_SLASH 1
 #define DEFAULT_ENCODE_SKIP_UNSUPPORTED_VALUE_TYPES 0
-#define DEFAULT_decode_null_object_value_as_nil 0
+#define DEFAULT_DECODE_NULL_OBJECT_VALUE_AS_NIL 0
 
 #ifdef DISABLE_INVALID_NUMBERS
 #undef DEFAULT_DECODE_INVALID_NUMBERS
@@ -493,7 +493,7 @@ static void json_create_config(lua_State *l)
     cfg->decode_array_with_array_mt = DEFAULT_DECODE_ARRAY_WITH_ARRAY_MT;
     cfg->encode_escape_forward_slash = DEFAULT_ENCODE_ESCAPE_FORWARD_SLASH;
     cfg->encode_skip_unsupported_value_types = DEFAULT_ENCODE_SKIP_UNSUPPORTED_VALUE_TYPES;
-    cfg->decode_null_object_value_as_nil = DEFAULT_decode_null_object_value_as_nil;
+    cfg->decode_null_object_value_as_nil = DEFAULT_DECODE_NULL_OBJECT_VALUE_AS_NIL;
 
 #if DEFAULT_ENCODE_KEEP_BUFFER > 0
     strbuf_init(&cfg->encode_buf, 0);
@@ -1326,7 +1326,7 @@ static void json_parse_object_context(lua_State *l, json_parse_t *json)
         /* Fetch value */
         json_next_token(json, &token);
         json_process_value(l, json, &token,
-                           json->cfg && json->cfg->decode_null_object_value_as_nil);
+                           json->cfg->decode_null_object_value_as_nil);
 
         /* Set key = value */
         lua_rawset(l, -3);

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -84,6 +84,7 @@
 #define DEFAULT_DECODE_ARRAY_WITH_ARRAY_MT 0
 #define DEFAULT_ENCODE_ESCAPE_FORWARD_SLASH 1
 #define DEFAULT_ENCODE_SKIP_UNSUPPORTED_VALUE_TYPES 0
+#define DEFAULT_DECODE_NULL_AS_NIL 0
 
 #ifdef DISABLE_INVALID_NUMBERS
 #undef DEFAULT_DECODE_INVALID_NUMBERS
@@ -168,6 +169,7 @@ typedef struct {
     int decode_max_depth;
     int decode_array_with_array_mt;
     int encode_skip_unsupported_value_types;
+    int decode_null_as_nil;
 } json_config_t;
 
 typedef struct {
@@ -390,6 +392,16 @@ static int json_cfg_encode_keep_buffer(lua_State *l)
     return 1;
 }
 
+/* Configures how to treat null when decoding */
+static int json_cfg_decode_null_as_nil(lua_State *l)
+{
+    json_config_t *cfg = json_arg_init(l, 1);
+
+    json_enum_option(l, 1, &cfg->decode_null_as_nil, NULL, 1);
+
+    return 1;
+}
+
 #if defined(DISABLE_INVALID_NUMBERS) && !defined(USE_INTERNAL_FPCONV)
 void json_verify_invalid_number_setting(lua_State *l, int *setting)
 {
@@ -481,6 +493,7 @@ static void json_create_config(lua_State *l)
     cfg->decode_array_with_array_mt = DEFAULT_DECODE_ARRAY_WITH_ARRAY_MT;
     cfg->encode_escape_forward_slash = DEFAULT_ENCODE_ESCAPE_FORWARD_SLASH;
     cfg->encode_skip_unsupported_value_types = DEFAULT_ENCODE_SKIP_UNSUPPORTED_VALUE_TYPES;
+    cfg->decode_null_as_nil = DEFAULT_DECODE_NULL_AS_NIL;
 
 #if DEFAULT_ENCODE_KEEP_BUFFER > 0
     strbuf_init(&cfg->encode_buf, 0);
@@ -1399,7 +1412,10 @@ static void json_process_value(lua_State *l, json_parse_t *json,
     case T_NULL:
         /* In Lua, setting "t[k] = nil" will delete k from the table.
          * Hence a NULL pointer lightuserdata object is used instead */
-        lua_pushlightuserdata(l, NULL);
+        if (json->cfg && json->cfg->decode_null_as_nil)
+            lua_pushnil(l);
+        else
+            lua_pushlightuserdata(l, NULL);
         break;;
     default:
         json_throw_parse_error(l, json, "value", token);
@@ -1521,6 +1537,7 @@ static int lua_cjson_new(lua_State *l)
         { "decode_invalid_numbers", json_cfg_decode_invalid_numbers },
         { "encode_escape_forward_slash", json_cfg_encode_escape_forward_slash },
         { "encode_skip_unsupported_value_types", json_cfg_encode_skip_unsupported_value_types },
+        { "decode_null_as_nil" , json_cfg_decode_null_as_nil },
         { "new", lua_cjson_new },
         { NULL, NULL }
     };

--- a/tests/agentzh.t
+++ b/tests/agentzh.t
@@ -345,8 +345,8 @@ local t2 = cjson.decode(json)
 print(t2.key1 == nil and "key1 is nil" or "key1 is not nil")
 
 -- array null are not changed
-local json_arr = [[[null, "value2"]]]
-local t = cjson.decode(json)
+local json_arr = '[null, "value2"]'
+local t = cjson.decode(json_arr)
 print(t[1] == cjson.null and "index 1 is null" or "key1 is not null")
 --- out
 key1 is null

--- a/tests/agentzh.t
+++ b/tests/agentzh.t
@@ -340,9 +340,15 @@ local cjson = require "cjson"
 local json = [[{"key1":null,"key2":"value2"}]]
 local t = cjson.decode(json)
 print(t.key1 == cjson.null and "key1 is null" or "key1 is not null")
-cjson.decode_null_as_nil(true)
+cjson.decode_null_object_value_as_nil(true)
 local t2 = cjson.decode(json)
 print(t2.key1 == nil and "key1 is nil" or "key1 is not nil")
+
+-- array null are not changed
+local json_arr = [[[null, "value2"]]]
+local t = cjson.decode(json)
+print(t[1] == cjson.null and "index 1 is null" or "key1 is not null")
 --- out
 key1 is null
 key1 is nil
+index 1 is null

--- a/tests/agentzh.t
+++ b/tests/agentzh.t
@@ -332,3 +332,17 @@ Cannot serialise function: type not supported
 
 {"valid":"valid"}
 ["one","two","three"]
+
+
+=== TEST 23: decode null as nil switch
+--- lua
+local cjson = require "cjson"
+local json = [[{"key1":null,"key2":"value2"}]]
+local t = cjson.decode(json)
+print(t.key1 == cjson.null and "key1 is null" or "key1 is not null")
+cjson.decode_null_as_nil(true)
+local t2 = cjson.decode(json)
+print(t2.key1 == nil and "key1 is nil" or "key1 is not nil")
+--- out
+key1 is null
+key1 is nil


### PR DESCRIPTION
```lua
local cjson = require "cjson"
local json = [[{"key1":null,"key2":"value2"}]]
local t = cjson.decode(json)
print(t.key1 == cjson.null and "key1 is null" or "key1 is not null")
cjson.decode_null_as_nil(true)
local t2 = cjson.decode(json)
print(t2.key1 == nil and "key1 is nil" or "key1 is not nil")
```